### PR TITLE
Update Ascii.java

### DIFF
--- a/guava/src/com/google/common/base/Ascii.java
+++ b/guava/src/com/google/common/base/Ascii.java
@@ -429,6 +429,11 @@ public final class Ascii {
    *
    * @since 14.0
    */
+  /*
+   Index Checker treats CharSequence and String differently as CharSequence could be a mutable-length collection.
+   Therefore, it considers chars length and newChars length, both as different which gives error
+   and should be suppressed.
+  */
   @SuppressWarnings("index")
   public static String toLowerCase(CharSequence chars) {
     if (chars instanceof String) {
@@ -480,6 +485,11 @@ public final class Ascii {
    *
    * @since 14.0
    */
+  /*
+   Index Checker treats CharSequence and String differently as CharSequence could be a mutable-length collection.
+   Therefore, it considers chars length and newChars length, both as different which gives error
+   and should be suppressed.
+  */
   @SuppressWarnings("index")
   public static String toUpperCase(CharSequence chars) {
     if (chars instanceof String) {

--- a/guava/src/com/google/common/base/Ascii.java
+++ b/guava/src/com/google/common/base/Ascii.java
@@ -429,12 +429,7 @@ public final class Ascii {
    *
    * @since 14.0
    */
-  /*
-   Index Checker treats CharSequence and String differently as CharSequence could be a mutable-length collection.
-   Therefore, it considers chars length and newChars length, both as different which gives error
-   and should be suppressed.
-  */
-  @SuppressWarnings("index")
+  @SuppressWarnings("index") // https://github.com/typetools/checker-framework/issues/2561
   public static String toLowerCase(CharSequence chars) {
     if (chars instanceof String) {
       return toLowerCase((String) chars);
@@ -485,12 +480,7 @@ public final class Ascii {
    *
    * @since 14.0
    */
-  /*
-   Index Checker treats CharSequence and String differently as CharSequence could be a mutable-length collection.
-   Therefore, it considers chars length and newChars length, both as different which gives error
-   and should be suppressed.
-  */
-  @SuppressWarnings("index")
+  @SuppressWarnings("index") // https://github.com/typetools/checker-framework/issues/2561
   public static String toUpperCase(CharSequence chars) {
     if (chars instanceof String) {
       return toUpperCase((String) chars);

--- a/guava/src/com/google/common/base/Ascii.java
+++ b/guava/src/com/google/common/base/Ascii.java
@@ -429,6 +429,7 @@ public final class Ascii {
    *
    * @since 14.0
    */
+  @SuppressWarnings("index")
   public static String toLowerCase(CharSequence chars) {
     if (chars instanceof String) {
       return toLowerCase((String) chars);
@@ -479,6 +480,7 @@ public final class Ascii {
    *
    * @since 14.0
    */
+  @SuppressWarnings("index")
   public static String toUpperCase(CharSequence chars) {
     if (chars instanceof String) {
       return toUpperCase((String) chars);


### PR DESCRIPTION
Added `@SuppressWarning` as Charsequence could be a mutable-length collection, the interaction between CharSequence and String in the Index Checker can be somewhat confusing because String is a subtype of CharSequence, but the Index Checker treats them differently.
Issue-[#2561](https://github.com/typetools/checker-framework/issues/2561)